### PR TITLE
Fix dirty tracking for duplicated objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,5 @@
     "typescript-eslint-parser": "21.0.2",
     "winston": "^2.3.1"
   },
-  "version": "0.10.29"
+  "version": "0.10.30"
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -736,6 +736,7 @@ export class SpraypaintBase {
     cloned.isMarkedForDisassociation = this.isMarkedForDisassociation
     cloned.errors = Object.assign({}, this.errors)
     cloned.links = Object.assign({}, this.links)
+    cloned._originalAttributes = cloneDeep(this._originalAttributes)
     return cloned
   }
 


### PR DESCRIPTION
Duplicate `_original_attributes` to keep track of dirty objects while making a copy of object using `dup` method